### PR TITLE
Option to list only windows from front application

### DIFF
--- a/Azayaka/AppDelegate.swift
+++ b/Azayaka/AppDelegate.swift
@@ -52,6 +52,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SCStreamDelegate, SCStreamOu
                 "encoder": Encoder.h264.rawValue,
                 "saveDirectory": saveDirectory,
                 "hideSelf": false,
+                Preferences.frontAppKey: false,
                 "showMouse": true,
                 "recordMic": false
             ]
@@ -75,11 +76,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, SCStreamDelegate, SCStreamOu
             }
             self.availableContent = content
             assert(self.availableContent?.displays.isEmpty != nil, "There needs to be at least one display connected")
+            let frontOnly = UserDefaults.standard.bool(forKey: Preferences.frontAppKey)
             DispatchQueue.main.async {
                 if buildMenu {
                     self.createMenu()
                 }
-                self.refreshWindows() // ask to just refresh the windows list instead of rebuilding it all
+                self.refreshWindows(frontOnly: frontOnly) 
+                // ask to just refresh the windows list instead of rebuilding it all
             }
         }
     }

--- a/Azayaka/Preferences.swift
+++ b/Azayaka/Preferences.swift
@@ -10,12 +10,14 @@ import AVFAudio
 import AVFoundation
 
 struct Preferences: View {
+    static let frontAppKey = "frontAppOnly"
     @AppStorage("audioFormat")   private var audioFormat: AudioFormat = .aac
     @AppStorage("audioQuality")  private var audioQuality: AudioQuality = .high
     @AppStorage("frameRate")     private var frameRate: Int = 60
     @AppStorage("videoFormat")   private var videoFormat: VideoFormat = .mp4
     @AppStorage("encoder")       private var encoder: Encoder = .h264
     @AppStorage("saveDirectory") private var saveDirectory: String?
+    @AppStorage(Self.frontAppKey) private var frontApp: Bool = false
     @AppStorage("hideSelf")      private var hideSelf: Bool = false
     @AppStorage("showMouse")     private var showMouse: Bool = true
     @AppStorage("recordMic")     private var recordMic: Bool = false
@@ -42,6 +44,9 @@ struct Preferences: View {
                 }.frame(maxWidth: .infinity).padding(.top, 10)
                 Toggle(isOn: $hideSelf) {
                     Text("Exclude Azayaka itself")
+                }.toggleStyle(CheckboxToggleStyle())
+                Toggle(isOn: $frontApp) {
+                    Text("Include only front app")
                 }.toggleStyle(CheckboxToggleStyle())
                 Toggle(isOn: $showMouse) {
                     Text("Show mouse cursor")

--- a/Azayaka/Preferences.swift
+++ b/Azayaka/Preferences.swift
@@ -46,7 +46,7 @@ struct Preferences: View {
                     Text("Exclude Azayaka itself")
                 }.toggleStyle(CheckboxToggleStyle())
                 Toggle(isOn: $frontApp) {
-                    Text("Include only front app")
+                    Text("Only list focused app's windows")
                 }.toggleStyle(CheckboxToggleStyle())
                 Toggle(isOn: $showMouse) {
                     Text("Show mouse cursor")


### PR DESCRIPTION
PR:
- Creates a Bool preference to restrict windows listed to the frontmost app
- Adds a Bool parameter to the menu-updating code listing windows
- Updates the existing window-listing filter to implement the preference/parameter

Manually tested on macOS 14. 

Note filtering now assumes an owning application and non-empty title in all cases.